### PR TITLE
Fix casing of WordPress title

### DIFF
--- a/docs/examples/wordpress.md
+++ b/docs/examples/wordpress.md
@@ -1,14 +1,14 @@
 ---
-title: Wordpress
+title: WordPress
 lang: en-US
 ---
 
-# Wordpress
+# WordPress
 
-Wordpress integration is possible via [WP Serverless Forms](https://wordpress.org/plugins/wp-serverless-forms/#description).
+WordPress integration is possible via [WP Serverless Forms](https://wordpress.org/plugins/wp-serverless-forms/#description).
 
 1. Download, install and activate [WP Serverless Forms](https://wordpress.org/plugins/wp-serverless-forms/#description).
 2. Copy your form's action URL.
 3. Paste the action URL into the `HTTP Endpoint` field on your Settings page.
 
-![Wordpress endpoint](../.vuepress/public/wp-serverless-forms-endpoint.png)
+![WordPress endpoint](../.vuepress/public/wp-serverless-forms-endpoint.png)


### PR DESCRIPTION
This changes the title from "Wordpress" to "WordPress", as it is a [trademark](https://wordpressfoundation.org/trademark-policy/).