### PR TITLE
Only deploy on pushes to master

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -1,6 +1,10 @@
 name: Continuous deployment
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- The deploy workflow's trigger was `on: [push]`, which fires on every branch push (including PR feature branches). Scope it to pushes targeting `master`.
- Add `workflow_dispatch` so you can still kick off a deploy manually from the Actions UI when needed.

## Test plan
- [ ] Push to a branch other than master and confirm the Continuous deployment workflow does NOT run.
- [ ] Merge a PR to master and confirm the workflow does run and deploys.
- [ ] Trigger the workflow manually from the Actions tab and confirm it runs.