### PR TITLE
Add Astro/HTMX examples and Airtable/Sheets/Notion integration guides

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -136,8 +136,10 @@ export default {
         items: [
           { text: "AJAX submissions", link: "/examples/ajax" },
           { text: "Alpine.js", link: "/examples/alpinejs" },
+          { text: "Astro", link: "/examples/astro" },
           { text: "Framer", link: "/examples/framer" },
           { text: "Gatsby", link: "/examples/gatsby" },
+          { text: "HTMX", link: "/examples/htmx" },
           { text: "Hugo", link: "/examples/hugo" },
           { text: "Jekyll", link: "/examples/jekyll" },
           { text: "Next.js", link: "/examples/nextjs" },
@@ -154,6 +156,9 @@ export default {
       {
         text: "Integration",
         items: [
+          { text: "Airtable", link: "/integration/airtable" },
+          { text: "Google Sheets", link: "/integration/google-sheets" },
+          { text: "Notion", link: "/integration/notion" },
           { text: "Slack", link: "/integration/slack" },
           { text: "Webhooks", link: "/integration/webhooks" },
           { text: "UTM parameters", link: "/integration/utm-parameters" },

--- a/docs/examples/astro.md
+++ b/docs/examples/astro.md
@@ -1,0 +1,67 @@
+---
+title: Astro
+lang: en-US
+---
+
+# Astro
+
+## HTML
+
+Astro ships zero JavaScript by default, so a plain HTML form inside a `.astro` page is the recommended approach.
+
+```astro
+---
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+---
+
+<form action={FORMSPARK_ACTION_URL} method="POST">
+  <label>
+    <span>Message</span>
+    <textarea name="message"></textarea>
+  </label>
+  <button type="submit">Send</button>
+</form>
+```
+
+## Fetch
+
+Add a `<script>` block to your `.astro` page to submit the form without a page reload.
+
+```astro
+---
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+---
+
+<form id="contact" data-action={FORMSPARK_ACTION_URL}>
+  <label>
+    <span>Message</span>
+    <textarea name="message"></textarea>
+  </label>
+  <button type="submit">Send</button>
+</form>
+
+<script>
+  const form = document.getElementById("contact") as HTMLFormElement;
+  const action = form.dataset.action!;
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = form.querySelector("button")!;
+    button.disabled = true;
+    try {
+      await fetch(action, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(Object.fromEntries(new FormData(form))),
+      });
+      form.reset();
+      alert("Form submitted");
+    } finally {
+      button.disabled = false;
+    }
+  });
+</script>
+```

--- a/docs/examples/htmx.md
+++ b/docs/examples/htmx.md
@@ -1,0 +1,37 @@
+---
+title: HTMX
+lang: en-US
+---
+
+# HTMX
+
+Formspark returns a JSON response (when `Accept: application/json` is set), so we use `hx-swap="none"` to prevent HTMX from replacing the form with the response, and show a thank-you message via `hx-on::after-request`.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Formspark | HTMX</title>
+    <script src="https://unpkg.com/htmx.org@2"></script>
+    <script src="https://unpkg.com/htmx-ext-json-enc@2"></script>
+  </head>
+  <body>
+    <form
+      hx-post="https://submit-form.com/your-form-id"
+      hx-ext="json-enc"
+      hx-headers='{"Accept": "application/json"}'
+      hx-swap="none"
+      hx-on::after-request="if(event.detail.successful){this.reset();document.getElementById('thanks').hidden=false}"
+    >
+      <label>
+        <span>Message</span>
+        <textarea name="message"></textarea>
+      </label>
+      <button type="submit">Send</button>
+    </form>
+
+    <div id="thanks" hidden>Thanks! We received your message.</div>
+  </body>
+</html>
+```

--- a/docs/integration/airtable.md
+++ b/docs/integration/airtable.md
@@ -1,0 +1,29 @@
+---
+title: Airtable
+lang: en-US
+---
+
+# Airtable
+
+Formspark does not connect to Airtable directly. The recommended path is to use Zapier or Make as a bridge.
+
+## Via Zapier
+
+1. Set up the Formspark [Zapier integration](/integration/zapier).
+2. In your Zap, select `New Submission` as the trigger.
+3. Add `Airtable` as the action and choose `Create Record`.
+4. Map your form fields to the matching Airtable columns.
+
+Zapier transparently handles Airtable's API rate limit (5 requests per second), so this is the safest option for higher-volume forms.
+
+## Via Make
+
+1. Set up the Formspark [Make integration](/integration/make).
+2. In your scenario, select `Formspark` → `New Submission` as the trigger.
+3. Add an `Airtable` → `Create a Record` module.
+4. Map your form fields to the matching Airtable columns.
+
+## Tips
+
+- The names of your form's input fields should be easy to identify so you can confidently map them to Airtable columns.
+- Test your form before going live to verify records are being created as expected.

--- a/docs/integration/google-sheets.md
+++ b/docs/integration/google-sheets.md
@@ -1,0 +1,35 @@
+---
+title: Google Sheets
+lang: en-US
+---
+
+# Google Sheets
+
+Formspark does not connect to Google Sheets directly. The recommended path is to use Zapier or Make as a bridge. For developers, a Google Apps Script webhook is also an option.
+
+## Via Zapier
+
+1. Set up the Formspark [Zapier integration](/integration/zapier).
+2. In your Zap, select `New Submission` as the trigger.
+3. Add `Google Sheets` as the action and choose `Create Spreadsheet Row`.
+4. Map your form fields to the matching spreadsheet columns.
+
+## Via Make
+
+1. Set up the Formspark [Make integration](/integration/make).
+2. In your scenario, select `Formspark` → `New Submission` as the trigger.
+3. Add a `Google Sheets` → `Add a Row` module.
+4. Map your form fields to the matching spreadsheet columns.
+
+The free tier of both Zapier and Make is sufficient for typical low-volume contact forms.
+
+## Via webhook (Google Apps Script)
+
+If you'd rather skip a third-party automation tool, you can deploy a Google Apps Script as a web app and use its URL as your form's webhook.
+
+1. Open your spreadsheet and go to `Extensions` → `Apps Script`.
+2. Write a `doPost(e)` function that appends `e.postData.contents` to the active sheet.
+3. Deploy the script as a web app with access set to `Anyone`.
+4. Paste the deployment URL into your form's `Webhook URL` field.
+
+[Check this page](/integration/webhooks) to learn more about webhooks.

--- a/docs/integration/notion.md
+++ b/docs/integration/notion.md
@@ -1,0 +1,26 @@
+---
+title: Notion
+lang: en-US
+---
+
+# Notion
+
+Formspark does not connect to Notion directly. The recommended path is to use Zapier or Make as a bridge.
+
+## Via Zapier
+
+1. Set up the Formspark [Zapier integration](/integration/zapier).
+2. In your Zap, select `New Submission` as the trigger.
+3. Add `Notion` as the action and choose `Create Database Item`.
+4. Map your form fields to the matching Notion database properties.
+
+## Via Make
+
+1. Set up the Formspark [Make integration](/integration/make).
+2. In your scenario, select `Formspark` → `New Submission` as the trigger.
+3. Add a `Notion` → `Create a Database Item` module.
+4. Map your form fields to the matching Notion database properties.
+
+## A note on direct webhooks
+
+It is possible to point your form's `Webhook URL` directly at Notion's API, but Notion enforces a 3-requests-per-second rate limit and returns submission errors that need to be retried. Zapier and Make handle this for you, so we recommend going through one of them unless you are comfortable building your own retry layer.


### PR DESCRIPTION
## Summary

- New framework examples: **Astro** (plain HTML form + Fetch via inline `<script>`) and **HTMX** (`hx-post` + `hx-swap="none"` for JSON endpoints)
- New integration landing pages for **Airtable**, **Google Sheets**, and **Notion** — all route users through Zapier or Make. Sheets also documents a Google Apps Script webhook fallback; Notion calls out the 3 req/s API rate limit
- Sidebar updated in `docs/.vitepress/config.js`: Astro/HTMX inserted alphabetically in Examples; Airtable/Google Sheets/Notion grouped at the top of Integration

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run dev` and visually confirm `/examples/astro`, `/examples/htmx`, `/integration/airtable`, `/integration/google-sheets`, `/integration/notion` render with the correct sidebar entries
- [x] Sidebar order matches the conventions of neighboring entries