### PR TITLE
Docs tour: answer recurring customer questions, restructure integration sidebar

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -49,6 +49,7 @@ export default {
   ],
   themeConfig: {
     logo: "https://cdn.formspark.io/images/formspark/logos/formspark.svg",
+    outline: [2, 3],
     editLink: {
       pattern:
         "https://github.com/formspark/documentation/edit/master/docs/:path",
@@ -154,17 +155,21 @@ export default {
         ],
       },
       {
-        text: "Integration",
+        text: "Integrations",
         items: [
           { text: "Airtable", link: "/integration/airtable" },
           { text: "Google Sheets", link: "/integration/google-sheets" },
           { text: "Notion", link: "/integration/notion" },
           { text: "Slack", link: "/integration/slack" },
-          { text: "Webhooks", link: "/integration/webhooks" },
           { text: "UTM parameters", link: "/integration/utm-parameters" },
-          { text: "Zapier", link: "/integration/zapier" },
+          { text: "Webhooks", link: "/integration/webhooks" },
+        ],
+      },
+      {
+        text: "Automation",
+        items: [
           { text: "Make", link: "/integration/make" },
-          { text: "Integromat", link: "/integration/integromat" },
+          { text: "Zapier", link: "/integration/zapier" },
         ],
       },
       {

--- a/docs/customization/custom-routing.md
+++ b/docs/customization/custom-routing.md
@@ -10,30 +10,6 @@ You can use JavaScript to dynamically select a form endpoint.
 Using this technique, you can use a drop-down to dynamically route submissions to a specific team, department, inbox,
 webhook, etc...
 
-## At build time
-
-If your form lives on a static site and the destination only depends on the page (not on a user choice), set the `action` at build time so no JavaScript is needed.
-
-### Hugo
-
-```html
-<!-- layouts/_default/contact.html -->
-<form action="https://submit-form.com/{{ .Site.Params.formspark_form_id }}">
-  <textarea name="message"></textarea>
-  <button type="submit">Send</button>
-</form>
-```
-
-### Jekyll
-
-```html
-<!-- _layouts/contact.html -->
-<form action="https://submit-form.com/{{ site.formspark_form_id }}">
-  <textarea name="message"></textarea>
-  <button type="submit">Send</button>
-</form>
-```
-
 ## At runtime
 
 ```html
@@ -67,4 +43,28 @@ If your form lives on a static site and the destination only depends on the page
     document.getElementById("my-form").action = action;
   };
 </script>
+```
+
+## At build time
+
+If your form lives on a static site and the destination only depends on the page (not on a user choice), set the `action` at build time so no JavaScript is needed.
+
+### Hugo
+
+```html
+<!-- layouts/_default/contact.html -->
+<form action="https://submit-form.com/{{ .Site.Params.formspark_form_id }}">
+  <textarea name="message"></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+### Jekyll
+
+```html
+<!-- _layouts/contact.html -->
+<form action="https://submit-form.com/{{ site.formspark_form_id }}">
+  <textarea name="message"></textarea>
+  <button type="submit">Send</button>
+</form>
 ```

--- a/docs/customization/custom-routing.md
+++ b/docs/customization/custom-routing.md
@@ -10,6 +10,32 @@ You can use JavaScript to dynamically select a form endpoint.
 Using this technique, you can use a drop-down to dynamically route submissions to a specific team, department, inbox,
 webhook, etc...
 
+## At build time
+
+If your form lives on a static site and the destination only depends on the page (not on a user choice), set the `action` at build time so no JavaScript is needed.
+
+### Hugo
+
+```html
+<!-- layouts/_default/contact.html -->
+<form action="https://submit-form.com/{{ .Site.Params.formspark_form_id }}">
+  <textarea name="message"></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+### Jekyll
+
+```html
+<!-- _layouts/contact.html -->
+<form action="https://submit-form.com/{{ site.formspark_form_id }}">
+  <textarea name="message"></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+## At runtime
+
 ```html
 <form id="my-form" action="https://submit-form.com/sales-form-id" method="POST">
   <label for="department">Department</label>

--- a/docs/customization/direct-replies.md
+++ b/docs/customization/direct-replies.md
@@ -16,6 +16,10 @@ To activate this feature, create an input with any of the following names:
 - `_replyto`
 - `_email.replyto`
 
+::: tip
+Use `type="email"` so the browser validates the address before submission.
+:::
+
 ```html
 <input type="email" name="mail" placeholder="your@email.example" />
 ```

--- a/docs/customization/redirection.md
+++ b/docs/customization/redirection.md
@@ -55,6 +55,10 @@ automatically be inherited.
 </form>
 ```
 
+::: tip
+`_redirect` is only used for full-page form submissions. When you submit via AJAX with `Accept: application/json`, Formspark returns a JSON response instead and `_redirect` is silently ignored. Handle the post-submission UX yourself in JavaScript.
+:::
+
 ## Preventing the redirect
 
 ### Staying on the same page (without leaving it)

--- a/docs/dashboard/additional-workspaces.md
+++ b/docs/dashboard/additional-workspaces.md
@@ -18,3 +18,7 @@ workspace.
 2. Fill the form and press `Create`
 
 ![New workspace](/new-workspace.png)
+
+## Moving a form to another workspace
+
+Forms cannot be moved between workspaces from the dashboard. If you need to transfer a form, [contact support](mailto:support@formspark.io) and we'll move it for you.

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,8 +1,0 @@
----
-title: Debug
-lang: en-US
----
-
-# Debug
-
-<button onclick="fakeDebugFunction()">Test Sentry</button>

--- a/docs/examples/ajax.md
+++ b/docs/examples/ajax.md
@@ -7,28 +7,105 @@ lang: en-US
 
 You can use AJAX to submit your forms.
 
-To do so, make a `GET` or `POST` request to your form endpoint (https://submit-form.com/your-form-id).
+To do so, make a `POST` request to your form endpoint (https://submit-form.com/your-form-id).
 
 Ensure that both the `Content-Type` and `Accept` headers are set to `application/json` (some HTTP libraries do this
 automatically).
-
-We have included examples for: Axios, Fetch, jQuery and JavaScript XHR.
 
 If you wish to include special fields and customizations, which require hidden fields such as `_email.subject`
 and `_email.from`, include them as a nested object in the payload:
 
 ```javascript
-axios.post("https://submit-form.com/your-form-id", {
-  message: "Hello, World",
-  _email: {
-    from: "A Human Being",
-    subject: "A message awaits.",
-    template: {
-      title: false,
-      footer: false,
-    },
+fetch("https://submit-form.com/your-form-id", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
   },
+  body: JSON.stringify({
+    message: "Hello, World",
+    _email: {
+      from: "A Human Being",
+      subject: "A message awaits.",
+      template: {
+        title: false,
+        footer: false,
+      },
+    },
+  }),
 });
+```
+
+## Fetch
+
+The modern, dependency-free way to submit a form.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Formspark | AJAX with Fetch</title>
+  </head>
+  <body>
+    <script>
+      async function submit() {
+        try {
+          const response = await fetch("https://submit-form.com/your-form-id", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            body: JSON.stringify({
+              message: "Hello, World",
+            }),
+          });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          console.log("Submitted");
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      submit();
+    </script>
+  </body>
+</html>
+```
+
+## Fetch with reCAPTCHA v2
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Formspark | AJAX with Fetch and reCAPTCHA v2</title>
+    <script src="https://www.google.com/recaptcha/api.js" async></script>
+  </head>
+  <body>
+    <div class="g-recaptcha" data-sitekey="your-site-key"></div>
+    <button id="send-button" type="button">Send</button>
+    <script>
+      document
+        .getElementById("send-button")
+        .addEventListener("click", async () => {
+          await fetch("https://submit-form.com/your-form-id", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            body: JSON.stringify({
+              message: "Hello, World",
+              "g-recaptcha-response": grecaptcha.getResponse(),
+            }),
+          });
+        });
+    </script>
+  </body>
+</html>
 ```
 
 ## Axios
@@ -47,12 +124,8 @@ axios.post("https://submit-form.com/your-form-id", {
         .post("https://submit-form.com/your-form-id", {
           message: "Hello, World",
         })
-        .then(function (response) {
-          console.log(response);
-        })
-        .catch(function (response) {
-          console.error(response);
-        });
+        .then((response) => console.log(response))
+        .catch((error) => console.error(error));
     </script>
   </body>
 </html>
@@ -80,12 +153,8 @@ axios.post("https://submit-form.com/your-form-id", {
             message: "Hello, World",
             _botpoison: solution,
           })
-          .then(function (response) {
-            console.log(response);
-          })
-          .catch(function (response) {
-            console.error(response);
-          });
+          .then((response) => console.log(response))
+          .catch((error) => console.error(error));
       });
     </script>
   </body>
@@ -107,99 +176,22 @@ axios.post("https://submit-form.com/your-form-id", {
     <div class="g-recaptcha" data-sitekey="your-site-key"></div>
     <button id="send-button" type="button">Send</button>
     <script>
-      document
-        .getElementById("send-button")
-        .addEventListener("click", function () {
-          axios
-            .post("https://submit-form.com/your-form-id", {
-              message: "Hello, World",
-              "g-recaptcha-response": grecaptcha.getResponse(),
-            })
-            .then(function (response) {
-              console.log(response);
-            })
-            .catch(function (response) {
-              console.error(response);
-            });
-        });
-    </script>
-  </body>
-</html>
-```
-
-## Fetch
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Formspark | AJAX with Fetch</title>
-  </head>
-  <body>
-    <script>
-      fetch("https://submit-form.com/your-form-id", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify({
+      document.getElementById("send-button").addEventListener("click", () => {
+        axios.post("https://submit-form.com/your-form-id", {
           message: "Hello, World",
-        }),
-      })
-        .then(function (response) {
-          console.log(response);
-        })
-        .catch(function (error) {
-          console.error(error);
+          "g-recaptcha-response": grecaptcha.getResponse(),
         });
+      });
     </script>
   </body>
 </html>
 ```
 
-## Fetch with reCAPTCHA v2
+## Legacy
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Formspark | AJAX with Fetch and reCAPTCHA v2</title>
-    <script src="https://www.google.com/recaptcha/api.js" async></script>
-  </head>
-  <body>
-    <div class="g-recaptcha" data-sitekey="your-site-key"></div>
-    <button id="send-button" type="button">Send</button>
-    <script>
-      document
-        .getElementById("send-button")
-        .addEventListener("click", function () {
-          fetch("https://submit-form.com/your-form-id", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "application/json",
-            },
-            body: JSON.stringify({
-              message: "Hello, World",
-              "g-recaptcha-response": grecaptcha.getResponse(),
-            }),
-          })
-            .then(function (response) {
-              console.log(response);
-            })
-            .catch(function (error) {
-              console.error(error);
-            });
-        });
-    </script>
-  </body>
-</html>
-```
+The patterns below still work, but we recommend Fetch for new code.
 
-## JavaScript XHR
+### JavaScript XHR
 
 ```html
 <!DOCTYPE html>
@@ -217,14 +209,14 @@ axios.post("https://submit-form.com/your-form-id", {
       xhr.send(
         JSON.stringify({
           message: "Hello, World!",
-        })
+        }),
       );
     </script>
   </body>
 </html>
 ```
 
-## jQuery
+### jQuery
 
 ```html
 <!DOCTYPE html>
@@ -242,14 +234,10 @@ axios.post("https://submit-form.com/your-form-id", {
           message: "Hello, World",
         },
         null,
-        "json" // dataType must be set to json
+        "json", // dataType must be set to json
       )
-        .then(function (response) {
-          console.log(response);
-        })
-        .catch(function (response) {
-          console.error(response);
-        });
+        .then((response) => console.log(response))
+        .catch((error) => console.error(error));
     </script>
   </body>
 </html>

--- a/docs/examples/ajax.md
+++ b/docs/examples/ajax.md
@@ -74,6 +74,42 @@ The modern, dependency-free way to submit a form.
 </html>
 ```
 
+## Fetch with Botpoison
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Formspark | AJAX with Fetch and Botpoison</title>
+    <script src="https://unpkg.com/@botpoison/browser" async></script>
+  </head>
+  <body>
+    <script>
+      async function submit() {
+        const botpoison = new Botpoison({
+          publicKey: "your-public-key",
+        });
+        const { solution } = await botpoison.challenge();
+        await fetch("https://submit-form.com/your-form-id", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            message: "Hello, World",
+            _botpoison: solution,
+          }),
+        });
+      }
+
+      submit();
+    </script>
+  </body>
+</html>
+```
+
 ## Fetch with reCAPTCHA v2
 
 ```html

--- a/docs/examples/alpinejs.md
+++ b/docs/examples/alpinejs.md
@@ -71,3 +71,70 @@ article: [Building an AJAX form with Alpine.js](https://technotrampoline.com/art
   </body>
 </html>
 ```
+
+## With success and error states
+
+Tracks three states (`idle`, `success`, `error`) so you can show a thank-you message on success or an inline error on failure without leaving the page.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Formspark | Alpine.js with states</title>
+    <script
+      src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"
+      defer
+    ></script>
+  </head>
+  <body>
+    <div x-data="contactForm()">
+      <form x-show="state !== 'success'" @submit.prevent="submit">
+        <label>
+          <span>Message</span>
+          <textarea name="message" x-model="data.message" required></textarea>
+        </label>
+        <button type="submit" :disabled="state === 'loading'">
+          <span x-show="state !== 'loading'">Submit</span>
+          <span x-show="state === 'loading'">Sending...</span>
+        </button>
+        <p x-show="state === 'error'" style="color: red">
+          Something went wrong. Please try again.
+        </p>
+      </form>
+
+      <p x-show="state === 'success'">Thanks! We received your message.</p>
+    </div>
+
+    <script>
+      const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+
+      function contactForm() {
+        return {
+          state: "idle",
+          data: {
+            message: "",
+          },
+          async submit() {
+            this.state = "loading";
+            try {
+              const response = await fetch(FORMSPARK_ACTION_URL, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  Accept: "application/json",
+                },
+                body: JSON.stringify(this.data),
+              });
+              if (!response.ok) throw new Error();
+              this.state = "success";
+            } catch {
+              this.state = "error";
+            }
+          },
+        };
+      }
+    </script>
+  </body>
+</html>
+```

--- a/docs/examples/gatsby.md
+++ b/docs/examples/gatsby.md
@@ -5,15 +5,85 @@ lang: en-US
 
 # Gatsby
 
+## HTML
+
 ```jsx
 import React from "react";
 
 const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
 
-export default function HomePage() {
+export default function ContactPage() {
   return (
     <form method="POST" action={FORMSPARK_ACTION_URL}>
       <textarea name="message" placeholder="Message" />
+      <button type="submit">Send</button>
+    </form>
+  );
+}
+```
+
+## use-formspark
+
+:::tip
+Check out our official React hooks: [use-formspark](https://github.com/formspark/use-formspark).
+:::
+
+```jsx
+import React, { useState } from "react";
+import { useFormspark } from "@formspark/use-formspark";
+
+const FORMSPARK_FORM_ID = "your-form-id";
+
+export default function ContactPage() {
+  const [submit, submitting] = useFormspark({
+    formId: FORMSPARK_FORM_ID,
+  });
+
+  const [message, setMessage] = useState("");
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    await submit({ message });
+    alert("Form submitted");
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <textarea value={message} onChange={(e) => setMessage(e.target.value)} />
+      <button type="submit" disabled={submitting}>
+        Send
+      </button>
+    </form>
+  );
+}
+```
+
+## Fetch
+
+```jsx
+import React, { useState } from "react";
+
+const FORMSPARK_ACTION_URL = "https://submit-form.com/your-form-id";
+
+export default function ContactPage() {
+  const [message, setMessage] = useState("");
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    await fetch(FORMSPARK_ACTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ message }),
+    });
+    alert("Form submitted");
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <textarea value={message} onChange={(e) => setMessage(e.target.value)} />
       <button type="submit">Send</button>
     </form>
   );

--- a/docs/examples/hugo.md
+++ b/docs/examples/hugo.md
@@ -5,6 +5,8 @@ lang: en-US
 
 # Hugo
 
+## Inline
+
 ```html
 <html>
   <head>
@@ -18,4 +20,29 @@ lang: en-US
     </form>
   </body>
 </html>
+```
+
+## Reusable partial
+
+Store the form ID once in your site config and render the form from a partial wherever you need it.
+
+```toml
+# hugo.toml
+[params]
+formspark_form_id = "your-form-id"
+```
+
+```html
+<!-- layouts/partials/contact-form.html -->
+<form action="https://submit-form.com/{{ .Site.Params.formspark_form_id }}">
+  <label for="message">Message</label>
+  <textarea id="message" name="message" required></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+Use it from any layout or page:
+
+```html
+{{ partial "contact-form.html" . }}
 ```

--- a/docs/examples/jekyll.md
+++ b/docs/examples/jekyll.md
@@ -5,6 +5,8 @@ lang: en-US
 
 # Jekyll
 
+## Inline
+
 ```html
 ---
 layout: default
@@ -14,4 +16,28 @@ layout: default
   <textarea name="message"></textarea>
   <button type="submit">Submit</button>
 </form>
+```
+
+## Reusable include
+
+Store the form ID once in your site config and render the form from an include wherever you need it.
+
+```yaml
+# _config.yml
+formspark_form_id: your-form-id
+```
+
+```html
+<!-- _includes/contact-form.html -->
+<form action="https://submit-form.com/{{ site.formspark_form_id }}">
+  <label for="message">Message</label>
+  <textarea id="message" name="message" required></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+Use it from any page or layout:
+
+```liquid
+{% include contact-form.html %}
 ```

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -5,7 +5,76 @@ lang: en-US
 
 # Next.js
 
-## use-formspark
+## App Router (Server Action)
+
+Keeps the form ID server-side and redirects after submission. No client JavaScript required.
+
+```jsx
+// app/contact/page.jsx
+import { redirect } from "next/navigation";
+
+async function submitForm(formData) {
+  "use server";
+  const body = Object.fromEntries(formData);
+  await fetch("https://submit-form.com/your-form-id", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  redirect("/thanks");
+}
+
+export default function ContactPage() {
+  return (
+    <form action={submitForm}>
+      <textarea name="message" required />
+      <button type="submit">Send</button>
+    </form>
+  );
+}
+```
+
+## App Router (client component)
+
+When you want a loading state or to stay on the same page after submission.
+
+```jsx
+// app/contact/page.jsx
+"use client";
+
+import { useState } from "react";
+import { useFormspark } from "@formspark/use-formspark";
+
+const FORMSPARK_FORM_ID = "your-form-id";
+
+export default function ContactPage() {
+  const [submit, submitting] = useFormspark({
+    formId: FORMSPARK_FORM_ID,
+  });
+
+  const [message, setMessage] = useState("");
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    await submit({ message });
+    alert("Form submitted");
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <textarea value={message} onChange={(e) => setMessage(e.target.value)} />
+      <button type="submit" disabled={submitting}>
+        Send
+      </button>
+    </form>
+  );
+}
+```
+
+## Pages Router (use-formspark)
 
 :::tip
 Check out our official React hooks: [use-formspark](https://github.com/formspark/use-formspark).
@@ -43,7 +112,7 @@ function ContactPage() {
 export default ContactPage;
 ```
 
-## Fetch
+## Pages Router (Fetch)
 
 ```jsx
 import React, { useState } from "react";

--- a/docs/examples/nuxtjs.md
+++ b/docs/examples/nuxtjs.md
@@ -5,6 +5,42 @@ lang: en-US
 
 # Nuxt
 
+## vue-use-formspark
+
+:::tip
+Check out our official Vue composition API
+functions: [vue-use-formspark](https://github.com/formspark/vue-use-formspark).
+:::
+
+```vue
+<script setup>
+import { ref } from "vue";
+import { useFormspark } from "@formspark/vue-use-formspark";
+
+const message = ref("");
+
+const [submit, submitting] = useFormspark({
+  formId: "your-form-id",
+});
+
+const onSubmit = async () => {
+  await submit({ message: message.value });
+  message.value = "";
+  alert("Form submitted");
+};
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <label>
+      <span>Message</span>
+      <textarea v-model="message" />
+    </label>
+    <button type="submit" :disabled="submitting">Send</button>
+  </form>
+</template>
+```
+
 ## Fetch
 
 ```vue

--- a/docs/examples/react.md
+++ b/docs/examples/react.md
@@ -80,3 +80,50 @@ const Application = () => {
 
 createRoot(document.getElementById("root")).render(<Application />);
 ```
+
+## React Hook Form
+
+[React Hook Form](https://react-hook-form.com/) pairs nicely with `use-formspark` for validation and field state.
+
+```jsx
+import { useForm } from "react-hook-form";
+import { useFormspark } from "@formspark/use-formspark";
+
+const FORMSPARK_FORM_ID = "your-form-id";
+
+export default function ContactForm() {
+  const [submit, submitting] = useFormspark({ formId: FORMSPARK_FORM_ID });
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm();
+
+  const onSubmit = async (data) => {
+    await submit(data);
+    reset();
+    alert("Form submitted");
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label>
+        <span>Email</span>
+        <input type="email" {...register("email", { required: true })} />
+      </label>
+      {errors.email && <p>An email address is required.</p>}
+
+      <label>
+        <span>Message</span>
+        <textarea {...register("message", { required: true, minLength: 10 })} />
+      </label>
+      {errors.message && <p>Please write at least 10 characters.</p>}
+
+      <button type="submit" disabled={submitting}>
+        Send
+      </button>
+    </form>
+  );
+}
+```

--- a/docs/html-form/drop-down-list.md
+++ b/docs/html-form/drop-down-list.md
@@ -9,7 +9,7 @@ The `<select>` element is used to create a drop-down list.
 
 Only the value(s) of the selected option(s) will be forwarded.
 
-Use the `multiple` attribute to specify whether multiple options can be selected at once
+Use the `multiple` attribute to specify whether multiple options can be selected at once.
 
 ```html
 <!-- Single option (selection persisted as a string) -->
@@ -33,6 +33,46 @@ Use the `multiple` attribute to specify whether multiple options can be selected
     <option value="potato">Potato</option>
     <option value="kale">Kale</option>
   </select>
+  <button type="submit">Submit</button>
+</form>
+```
+
+::: tip
+When a `multiple` select has nothing selected, the field is omitted from the submission entirely — the key will not appear in your data.
+:::
+
+## Grouped options
+
+Use `<optgroup>` to organize related options under a heading.
+
+```html
+<select name="car">
+  <optgroup label="European">
+    <option value="volvo">Volvo</option>
+    <option value="mercedes">Mercedes</option>
+    <option value="audi">Audi</option>
+  </optgroup>
+  <optgroup label="American">
+    <option value="ford">Ford</option>
+    <option value="tesla">Tesla</option>
+  </optgroup>
+</select>
+```
+
+## Autocomplete suggestions
+
+A `<datalist>` provides suggestions for a plain text input. Unlike `<select>`, the user can still type any value.
+
+```html
+<form action="https://submit-form.com/your-form-id">
+  <label for="country">Country</label>
+  <input list="countries" id="country" name="country" />
+  <datalist id="countries">
+    <option value="Belgium"></option>
+    <option value="France"></option>
+    <option value="Germany"></option>
+    <option value="Netherlands"></option>
+  </datalist>
   <button type="submit">Submit</button>
 </form>
 ```

--- a/docs/html-form/form-styling.md
+++ b/docs/html-form/form-styling.md
@@ -40,6 +40,78 @@ On this page you'll find tips, tricks and links to help you style your forms.
 </html>
 ```
 
+## Accessible form
+
+Pair every input with a `<label for>`, give focused fields a visible outline, and never rely on placeholder text as a label.
+
+```html
+<style>
+  .accessible-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 500px;
+    font-family: system-ui, sans-serif;
+  }
+  .accessible-form label {
+    font-weight: 600;
+  }
+  .accessible-form :is(input, textarea) {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+  .accessible-form :is(input, textarea):focus-visible {
+    outline: 3px solid #707ee7;
+    outline-offset: 2px;
+  }
+</style>
+
+<form class="accessible-form" action="https://submit-form.com/your-form-id">
+  <label for="email">Email</label>
+  <input id="email" name="email" type="email" required />
+
+  <label for="message">Message</label>
+  <textarea id="message" name="message" rows="5" required></textarea>
+
+  <button type="submit">Send</button>
+</form>
+```
+
+## Tailwind CSS
+
+```html
+<form
+  class="mx-auto flex max-w-md flex-col gap-3"
+  action="https://submit-form.com/your-form-id"
+>
+  <label for="email" class="font-semibold">Email</label>
+  <input
+    id="email"
+    name="email"
+    type="email"
+    required
+    class="rounded border border-gray-300 p-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-500"
+  />
+
+  <label for="message" class="font-semibold">Message</label>
+  <textarea
+    id="message"
+    name="message"
+    rows="5"
+    required
+    class="rounded border border-gray-300 p-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-500"
+  ></textarea>
+
+  <button
+    type="submit"
+    class="rounded bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700"
+  >
+    Send
+  </button>
+</form>
+```
+
 ## Add an asterisk to required field labels
 
 ![Required field label asterisk](/required-field-label-asterisk.png)
@@ -67,8 +139,54 @@ On this page you'll find tips, tricks and links to help you style your forms.
 </html>
 ```
 
+## Success and error states (AJAX)
+
+When you submit via AJAX, you control the post-submission UI yourself. A common pattern is to swap the form for a thank-you message on success and show an inline error on failure.
+
+```html
+<form id="contact" action="https://submit-form.com/your-form-id">
+  <label for="message">Message</label>
+  <textarea id="message" name="message" required></textarea>
+  <button type="submit">Send</button>
+  <p id="error" hidden>Something went wrong. Please try again.</p>
+</form>
+
+<div id="thanks" hidden>Thanks! We received your message.</div>
+
+<script>
+  const form = document.getElementById("contact");
+  const error = document.getElementById("error");
+  const thanks = document.getElementById("thanks");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    error.hidden = true;
+    const button = form.querySelector("button");
+    button.disabled = true;
+    button.textContent = "Sending...";
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(Object.fromEntries(new FormData(form))),
+      });
+      if (!response.ok) throw new Error();
+      form.hidden = true;
+      thanks.hidden = false;
+    } catch {
+      error.hidden = false;
+      button.disabled = false;
+      button.textContent = "Send";
+    }
+  });
+</script>
+```
+
 ## CSS frameworks
 
 - [Bootstrap](https://getbootstrap.com/)
-- [Milligram](https://milligram.io/)
 - [Tailwind CSS](https://tailwindcss.com/)
+- [Pico CSS](https://picocss.com/) — minimal, semantic, no classes required.

--- a/docs/html-form/form-validation.md
+++ b/docs/html-form/form-validation.md
@@ -7,16 +7,19 @@ lang: en-US
 
 We recommend using HTML5's built-in validation. It is very rich these days, and has good browser support.
 
+::: warning
+Formspark performs no server-side validation. Validate your inputs client-side before submission to avoid storing malformed data.
+:::
+
 ## Resources
 
 - [MDN: Form data validation](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation)
 - [HTML5 validation browser support](https://caniuse.com/#search=validation)
 - [MDN: the input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
 
-## Example
+## Required fields
 
-The `required` attribute is a boolean attribute.
-When present, it specifies that an input field must be filled out before submitting the form.
+The `required` attribute is a boolean attribute. When present, it specifies that an input field must be filled out before submitting the form.
 
 ```html
 <form action="https://submit-form.com/your-form-id">
@@ -25,3 +28,72 @@ When present, it specifies that an input field must be filled out before submitt
   <button type="submit">Send</button>
 </form>
 ```
+
+## Length constraints
+
+Use `minlength` and `maxlength` to constrain text inputs.
+
+```html
+<input type="text" name="username" minlength="3" maxlength="20" required />
+<textarea name="message" minlength="10" maxlength="500" required></textarea>
+```
+
+## Pattern matching
+
+Use `pattern` with a regular expression to enforce a specific format.
+
+```html
+<!-- US zip code -->
+<input
+  type="text"
+  name="zip"
+  pattern="\d{5}(-\d{4})?"
+  title="A 5-digit ZIP code (optionally followed by -4 digits)"
+  required
+/>
+```
+
+The `title` attribute is shown by the browser when the pattern fails.
+
+## Custom validation messages
+
+Use `setCustomValidity` to replace the default browser message.
+
+```html
+<form action="https://submit-form.com/your-form-id">
+  <input type="email" name="email" id="email" required />
+  <button type="submit">Send</button>
+</form>
+
+<script>
+  const email = document.getElementById("email");
+  email.addEventListener("invalid", () => {
+    email.setCustomValidity("Please enter a valid work email address.");
+  });
+  email.addEventListener("input", () => {
+    email.setCustomValidity("");
+  });
+</script>
+```
+
+## Styling invalid fields
+
+CSS pseudo-classes let you style validation state without JavaScript.
+
+```css
+/* Applies as soon as the field is invalid */
+input:invalid {
+  border-color: red;
+}
+
+/* Applies only after the user has interacted with the field */
+input:user-invalid {
+  border-color: red;
+}
+
+input:user-valid {
+  border-color: green;
+}
+```
+
+Prefer `:user-invalid` / `:user-valid` over `:invalid` / `:valid` so empty required fields don't appear red on page load.

--- a/docs/html-form/special-input-types.md
+++ b/docs/html-form/special-input-types.md
@@ -52,3 +52,35 @@ A hidden field lets you include data that cannot be seen or modified by users wh
   <button type="submit">Submit</button>
 </form>
 ```
+
+## Email, telephone, and URL
+
+These types are stored as plain strings on Formspark's side. Their value is that browsers validate the format and mobile keyboards switch to the appropriate layout.
+
+```html
+<input type="email" name="email" required />
+<input type="tel" name="phone" />
+<input type="url" name="website" />
+```
+
+## Number and range
+
+```html
+<input type="number" name="quantity" min="1" max="10" step="1" />
+<input type="range" name="satisfaction" min="0" max="10" />
+```
+
+## Date and color
+
+```html
+<input type="date" name="birthday" />
+<input type="color" name="brand-color" value="#707ee7" />
+```
+
+## File uploads
+
+::: warning
+`<input type="file">` does not work with Formspark directly. Browsers send file inputs as `multipart/form-data` and Formspark expects URL-encoded form data or JSON.
+
+To accept file uploads, use a storage provider such as Uploadcare and submit the resulting URL to Formspark. See [File uploads](/setup/file-uploads).
+:::

--- a/docs/html-form/submit-in-different-tab.md
+++ b/docs/html-form/submit-in-different-tab.md
@@ -13,3 +13,7 @@ When setting the `target` attribute to `_blank`, the form will be submitted in a
   <button type="submit">Subscribe</button>
 </form>
 ```
+
+::: warning
+Browsers may block the new tab if the submission isn't triggered by a direct user gesture (for example, a programmatic `form.submit()` call). On mobile, opening a new tab can interrupt the flow and feels broken to many users. Prefer staying on the same page with [AJAX](/examples/ajax) for a better experience.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,14 @@ Welcome to the documentation website for [Formspark](https://formspark.io?ref=do
 
 Formspark is a simple way to save information from your website via forms without having to set up a server.
 
-Formspark is perfect for static sites and works anywhere you can put an HTML form
+Formspark is perfect for static sites and works anywhere you can put an HTML form.
+
+## What it's good for
+
+Contact forms, newsletter signups, lead capture, surveys, feedback widgets, RSVPs, waitlists, and any HTML form that needs a place to send its data.
+
+## What it isn't
+
+Formspark is not a drag-and-drop form builder. You bring your own HTML; Formspark stores submissions, sends notifications, and forwards data to your tools.
 
 Don't have an account yet? [Sign up for free!](https://dashboard.formspark.io).

--- a/docs/integration/integromat.md
+++ b/docs/integration/integromat.md
@@ -5,23 +5,4 @@ lang: en-US
 
 # Integromat
 
-:::tip
-We also have a dedicated [Make](/integration/make) integration.
-:::
-
-Connecting Formspark and Integromat takes only seconds.
-
-1. Add the Formspark integration to your Integromat account
-   via [this link](https://www.integromat.com/en/apps/invite/139bc1347afadf0e97b8c53c18abd3fd).
-2. Open Integromat.
-3. Inside the scenario editor, create a new module and select `Formspark`.
-4. Select the `New Submission` trigger.
-5. Select or create a webhook.
-6. Copy the webhook URL (example: https://hook.integromat.com/0123456789)
-7. Open Formspark
-8. Paste the webhook URL into the `Webhook URL` field found in your form's settings.
-9. Send a test submission to your form.
-
-[Check this page](/integration/webhooks) to learn more about webhooks.
-
-![Formspark with Integromat](/formspark-integromat-example.png)
+Integromat is now [Make](https://www.make.com). See the [Make integration guide](/integration/make) for current setup instructions.

--- a/docs/integration/utm-parameters.md
+++ b/docs/integration/utm-parameters.md
@@ -21,7 +21,7 @@ Add the Formtrack script.
 Add a `data-formtrack` attribute to your form element.
 
 ```html
-<form action="https://submit-form.com" data-formtrack>
+<form action="https://submit-form.com/your-form-id" data-formtrack>
   <input type="text" name="message" />
   <button type="submit">Send</button>
 </form>
@@ -49,7 +49,7 @@ Include a `data-formtrack-params` attribute within your form element, and popula
 
 ```html
 <form
-  action="https://submit-form.com"
+  action="https://submit-form.com/your-form-id"
   data-formtrack
   data-formtrack-params="custom_param_1,custom_param_2"
 >

--- a/docs/integration/webhooks.md
+++ b/docs/integration/webhooks.md
@@ -40,7 +40,12 @@ The body of the POST request will look as follows:
 - Your endpoint should accept POST requests.
 - Your endpoint should be able to parse a JSON object.
 - Your endpoint's url length should not exceed 512 characters.
-- You can use a service like [httphq.com](https://httphq.com) to preview what the webhook requests will look like.
+
+To preview what the webhook requests look like before pointing them at your own server, use a public inspection service such as [httphq.com](https://httphq.com). Paste the temporary URL it gives you into the `Webhook URL` field and submit your form once.
+
+## Signature verification
+
+Formspark does not currently sign webhook requests. Anyone who learns your endpoint URL can send requests to it, so do not rely on the request origin for authentication. If you need stronger guarantees, keep your endpoint URL secret, validate the submission body against an expected shape, or require a shared secret in your request handler.
 
 ## Removal
 

--- a/docs/setup/file-uploads.md
+++ b/docs/setup/file-uploads.md
@@ -5,6 +5,19 @@ lang: en-US
 
 # File uploads
 
+::: tip
+Formspark stores a link to your uploaded file, not the file itself. You upload the file to a third-party storage provider and Formspark records the resulting URL with the submission.
+:::
+
+The example below uses Uploadcare. Any provider that returns a public URL after upload will work the same way.
+
+## Alternatives to Uploadcare
+
+- [Cloudinary](https://cloudinary.com/) — image and video focused, generous free tier.
+- [Filestack](https://www.filestack.com/) — drop-in widget similar to Uploadcare.
+- [Bunny Storage](https://bunny.net/storage/) — cheap edge storage with a simple HTTP API.
+- [Amazon S3 pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) — generate an upload URL from your own backend, then submit the resulting file URL to Formspark.
+
 ## Uploadcare
 
 Create a free Uploadcare account at [https://uploadcare.com/](https://uploadcare.com/), the free tier of Uploadcare

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -5,6 +5,10 @@ lang: en-US
 
 # Installation
 
+## Getting your form ID
+
+Every form in Formspark has its own action URL. To get one, sign in to the [Formspark dashboard](https://dashboard.formspark.io), create a new form, and copy its action URL from the form's `Setup` section. The URL ends with your form's unique ID.
+
 ## HTML
 
 ```html

--- a/docs/setup/spam-protection.md
+++ b/docs/setup/spam-protection.md
@@ -7,6 +7,20 @@ lang: en-US
 
 Every form falls victim to spambots at some point, how you handle them can affect your customers.
 
+## Which should I pick?
+
+| Provider                                                    | Visitor sees | Pricing     | Strength | Notes                                       |
+| ----------------------------------------------------------- | ------------ | ----------- | -------- | ------------------------------------------- |
+| [Botpoison](https://botpoison.com/)                         | Nothing      | Free / paid | Strong   | Recommended default.                        |
+| [Turnstile](https://www.cloudflare.com/products/turnstile/) | Nothing      | Free        | Strong   | Cloudflare's invisible challenge.           |
+| [hCaptcha](https://www.hcaptcha.com/)                       | Checkbox     | Free        | Strong   | Privacy-friendly reCAPTCHA alternative.     |
+| [reCAPTCHA](https://www.google.com/recaptcha/about/)        | Checkbox     | Free        | Strong   | Google's classic v2 checkbox.               |
+| [Akismet](https://akismet.com/)                             | Nothing      | Included    | Medium   | Pre-activated for every account.            |
+| Custom spam words                                           | Nothing      | Included    | Low      | Keyword blocklist on submission body.       |
+| Honeypot                                                    | Nothing      | Included    | Low      | Easy to bypass; pair with another provider. |
+
+If you're not sure, start with **Botpoison** or **Turnstile**: both are invisible to your visitors and require no interaction.
+
 Formspark offers the following solutions to prevent spam:
 
 - [Botpoison](https://botpoison.com/) integration
@@ -224,7 +238,7 @@ The total length of the list must not exceed 2,500 characters.
 ## Honeypot
 
 ::: warning
-While simple to implement, this technique is not the most effective.
+While simple to implement, this technique is not the most effective. Modern spam bots that execute JavaScript can detect hidden fields and skip them, bypassing the honeypot entirely. Pair it with another provider above for serious protection.
 :::
 
 The honeypot technique is a simple-to-implement spam prevention solution.

--- a/docs/setup/spam-protection.md
+++ b/docs/setup/spam-protection.md
@@ -9,15 +9,15 @@ Every form falls victim to spambots at some point, how you handle them can affec
 
 ## Which should I pick?
 
-| Provider                                                    | Visitor sees | Pricing     | Strength | Notes                                       |
-| ----------------------------------------------------------- | ------------ | ----------- | -------- | ------------------------------------------- |
-| [Botpoison](https://botpoison.com/)                         | Nothing      | Free / paid | Strong   | Recommended default.                        |
-| [Turnstile](https://www.cloudflare.com/products/turnstile/) | Nothing      | Free        | Strong   | Cloudflare's invisible challenge.           |
-| [hCaptcha](https://www.hcaptcha.com/)                       | Checkbox     | Free        | Strong   | Privacy-friendly reCAPTCHA alternative.     |
-| [reCAPTCHA](https://www.google.com/recaptcha/about/)        | Checkbox     | Free        | Strong   | Google's classic v2 checkbox.               |
-| [Akismet](https://akismet.com/)                             | Nothing      | Included    | Medium   | Pre-activated for every account.            |
-| Custom spam words                                           | Nothing      | Included    | Low      | Keyword blocklist on submission body.       |
-| Honeypot                                                    | Nothing      | Included    | Low      | Easy to bypass; pair with another provider. |
+| Provider                                                    | Visitor experience | Pricing     | Strength |
+| ----------------------------------------------------------- | ------------------ | ----------- | -------- |
+| [Botpoison](https://botpoison.com/)                         | Invisible          | Free / paid | Strong   |
+| [Turnstile](https://www.cloudflare.com/products/turnstile/) | Invisible          | Free        | Strong   |
+| [hCaptcha](https://www.hcaptcha.com/)                       | Checkbox           | Free        | Strong   |
+| [reCAPTCHA](https://www.google.com/recaptcha/about/)        | Checkbox           | Free        | Strong   |
+| [Akismet](https://akismet.com/)                             | Invisible          | Included    | Medium   |
+| Custom spam words                                           | Invisible          | Included    | Low      |
+| Honeypot                                                    | Invisible          | Included    | Low      |
 
 If you're not sure, start with **Botpoison** or **Turnstile**: both are invisible to your visitors and require no interaction.
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -30,3 +30,30 @@ Ensure that you are connected to the right workspace: [View My Workspaces](https
 
 Note that additional user-created workspaces start with 0 submissions. All upgrades, bundles, and deals are per
 workspace.
+
+## My AJAX request returns 200 but no submission shows up
+
+This is almost always a `Content-Type` / `Accept` header mismatch. When submitting JSON, both headers must be set to `application/json`:
+
+```javascript
+fetch("https://submit-form.com/your-form-id", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
+  body: JSON.stringify({ message: "Hello" }),
+});
+```
+
+Without those headers Formspark may treat the body as something other than JSON and silently discard it.
+
+## I'm receiving duplicate submissions
+
+Common causes:
+
+- The visitor pressed the back button after submitting and resubmitted the form on refresh.
+- The submit button was clicked multiple times before the request completed. Disable the button while the request is in flight.
+- Browser autofill / form-restore replayed the submission after a page reload.
+
+If you submit via AJAX, disable the button until the request resolves and reset the form on success. For full-page submissions, redirect away from the form on success to avoid resubmission on refresh.


### PR DESCRIPTION
Result of a page-by-page tour of the docs looking for missing answers, silent gotchas, and structural cleanup. Each change targets a question we're answering in support or a confusion a new user hits.

## Per-page additions

- **`index.md`** — "What it's good for" / "What it isn't"
- **`debug.md`** — deleted (Sentry test page, not for production)
- **`setup/index.md`** — explain where the form ID comes from
- **`setup/spam-protection.md`** — comparison table at top + honeypot bypass warning
- **`setup/file-uploads.md`** — alternatives (Cloudinary, Filestack, Bunny, S3) and "we store the URL, not the file"
- **`customization/redirection.md`** — `_redirect` is silently ignored on AJAX
- **`customization/direct-replies.md`** — recommend `type="email"`
- **`customization/custom-routing.md`** — build-time variant for static sites (Hugo + Jekyll)
- **`dashboard/additional-workspaces.md`** — transferring forms = contact support
- **`html-form/form-validation.md`** — `pattern` / `minlength` / `setCustomValidity` / `:user-invalid` + "no server-side validation"
- **`html-form/form-styling.md`** — accessible example, Tailwind variant, AJAX success/error states, swapped dead Milligram for Pico CSS
- **`html-form/special-input-types.md`** — tel/url/date/number/range/color + explicit warning that `<input type="file">` does NOT work
- **`html-form/drop-down-list.md`** — `<optgroup>`, `<datalist>`, and "empty `multiple` omits the key"
- **`html-form/submit-in-different-tab.md`** — pop-up blocker and mobile UX caveats
- **`examples/ajax.md`** — modernized: Fetch as primary with `async/await`, XHR/jQuery moved under Legacy
- **`examples/alpinejs.md`** — added a success/error state-machine variant
- **`examples/gatsby.md`** — added Fetch + use-formspark variants for parity with React/Next.js
- **`examples/hugo.md`** — added reusable partial + data param pattern
- **`examples/jekyll.md`** — added reusable include pattern
- **`examples/nextjs.md`** — added App Router (Server Action) + App Router (client) variants
- **`examples/nuxtjs.md`** — added `vue-use-formspark` variant
- **`examples/react.md`** — added React Hook Form snippet
- **`integration/webhooks.md`** — local-testing recommendation (httphq.com) + explicit "signatures not supported"
- **`integration/utm-parameters.md`** — fixed missing form ID in example action URL
- **`integration/integromat.md`** — replaced content with a redirect to Make
- **`troubleshooting/common-issues.md`** — duplicate submissions, AJAX 200 + no submission

## Structural changes

- **Sidebar**: split `Integration` into **Integrations** (Airtable, Google Sheets, Notion, Slack, UTM parameters, Webhooks) and **Automation** (Make, Zapier). Integromat removed from sidebar but page retained as a Make redirect for SEO.
- **Outline**: enabled `outline: [2, 3]` globally so long pages get a deeper right-side TOC.

## Test plan

- [x] `npm run build` succeeds locally
- [x] Visually verify the new sections render: spam-protection comparison table, file-uploads alternatives list, form-validation pattern examples, special-input-types file-upload warning, sidebar groups
- [x] Confirm `/integration/integromat` still resolves and links to Make
- [x] Confirm `/debug` returns 404