### PR TITLE
Review-session tweaks: sidebar, spam table, uploads, custom routing

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -159,16 +159,11 @@ export default {
         items: [
           { text: "Airtable", link: "/integration/airtable" },
           { text: "Google Sheets", link: "/integration/google-sheets" },
+          { text: "Make", link: "/integration/make" },
           { text: "Notion", link: "/integration/notion" },
           { text: "Slack", link: "/integration/slack" },
           { text: "UTM parameters", link: "/integration/utm-parameters" },
           { text: "Webhooks", link: "/integration/webhooks" },
-        ],
-      },
-      {
-        text: "Automation",
-        items: [
-          { text: "Make", link: "/integration/make" },
           { text: "Zapier", link: "/integration/zapier" },
         ],
       },

--- a/docs/customization/custom-routing.md
+++ b/docs/customization/custom-routing.md
@@ -10,8 +10,6 @@ You can use JavaScript to dynamically select a form endpoint.
 Using this technique, you can use a drop-down to dynamically route submissions to a specific team, department, inbox,
 webhook, etc...
 
-## At runtime
-
 ```html
 <form id="my-form" action="https://submit-form.com/sales-form-id" method="POST">
   <label for="department">Department</label>
@@ -43,28 +41,4 @@ webhook, etc...
     document.getElementById("my-form").action = action;
   };
 </script>
-```
-
-## At build time
-
-If your form lives on a static site and the destination only depends on the page (not on a user choice), set the `action` at build time so no JavaScript is needed.
-
-### Hugo
-
-```html
-<!-- layouts/_default/contact.html -->
-<form action="https://submit-form.com/{{ .Site.Params.formspark_form_id }}">
-  <textarea name="message"></textarea>
-  <button type="submit">Send</button>
-</form>
-```
-
-### Jekyll
-
-```html
-<!-- _layouts/contact.html -->
-<form action="https://submit-form.com/{{ site.formspark_form_id }}">
-  <textarea name="message"></textarea>
-  <button type="submit">Send</button>
-</form>
 ```

--- a/docs/setup/file-uploads.md
+++ b/docs/setup/file-uploads.md
@@ -11,13 +11,6 @@ Formspark stores a link to your uploaded file, not the file itself. You upload t
 
 The example below uses Uploadcare. Any provider that returns a public URL after upload will work the same way.
 
-## Alternatives to Uploadcare
-
-- [Cloudinary](https://cloudinary.com/) — image and video focused, generous free tier.
-- [Filestack](https://www.filestack.com/) — drop-in widget similar to Uploadcare.
-- [Bunny Storage](https://bunny.net/storage/) — cheap edge storage with a simple HTTP API.
-- [Amazon S3 pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) — generate an upload URL from your own backend, then submit the resulting file URL to Formspark.
-
 ## Uploadcare
 
 Create a free Uploadcare account at [https://uploadcare.com/](https://uploadcare.com/), the free tier of Uploadcare
@@ -101,3 +94,10 @@ Final code:
   </body>
 </html>
 ```
+
+## Alternatives
+
+- [Cloudinary](https://cloudinary.com/) — image and video focused, generous free tier.
+- [Filestack](https://www.filestack.com/) — drop-in widget similar to Uploadcare.
+- [Bunny Storage](https://bunny.net/storage/) — cheap edge storage with a simple HTTP API.
+- [Amazon S3 pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html) — generate an upload URL from your own backend, then submit the resulting file URL to Formspark.

--- a/docs/setup/spam-protection.md
+++ b/docs/setup/spam-protection.md
@@ -7,20 +7,6 @@ lang: en-US
 
 Every form falls victim to spambots at some point, how you handle them can affect your customers.
 
-## Which should I pick?
-
-| Provider                                                    | Visitor experience | Pricing     | Strength |
-| ----------------------------------------------------------- | ------------------ | ----------- | -------- |
-| [Botpoison](https://botpoison.com/)                         | Invisible          | Free / paid | Strong   |
-| [Turnstile](https://www.cloudflare.com/products/turnstile/) | Invisible          | Free        | Strong   |
-| [hCaptcha](https://www.hcaptcha.com/)                       | Checkbox           | Free        | Strong   |
-| [reCAPTCHA](https://www.google.com/recaptcha/about/)        | Checkbox           | Free        | Strong   |
-| [Akismet](https://akismet.com/)                             | Invisible          | Included    | Medium   |
-| Custom spam words                                           | Invisible          | Included    | Low      |
-| Honeypot                                                    | Invisible          | Included    | Low      |
-
-If you're not sure, start with **Botpoison** or **Turnstile**: both are invisible to your visitors and require no interaction.
-
 Formspark offers the following solutions to prevent spam:
 
 - [Botpoison](https://botpoison.com/) integration
@@ -38,6 +24,20 @@ Formspark will not save submissions, send notifications or decrement your submis
 - The submission is empty
 - The spam protection verification was unsuccessful
 - The submission contains a honeypot
+
+## Which should I pick?
+
+| Provider                                                    | Visitor experience | Pricing     | Strength |
+| ----------------------------------------------------------- | ------------------ | ----------- | -------- |
+| [Botpoison](https://botpoison.com/)                         | Invisible          | Free / paid | Strong   |
+| [Turnstile](https://www.cloudflare.com/products/turnstile/) | Invisible          | Free        | Strong   |
+| [hCaptcha](https://www.hcaptcha.com/)                       | Checkbox           | Free        | Strong   |
+| [reCAPTCHA](https://www.google.com/recaptcha/about/)        | Checkbox           | Free        | Strong   |
+| [Akismet](https://akismet.com/)                             | Invisible          | Included    | Medium   |
+| Custom spam words                                           | Invisible          | Included    | Low      |
+| Honeypot                                                    | Invisible          | Included    | Low      |
+
+If you're not sure, start with **Botpoison** or **Turnstile**: both are invisible to your visitors and require no interaction.
 
 ## Botpoison
 


### PR DESCRIPTION
## Summary

- Merge Make and Zapier back into the Integrations sidebar group; drop the separate Automation group introduced in #159.
- In spam protection, move the "Which should I pick?" comparison table below the conditions list so readers see what counts as spam first, then pick a provider.
- In file uploads, move the alternatives list below the Uploadcare walkthrough and rename the heading to "Alternatives".
- In custom routing, drop the "At build time" section and the "At runtime" heading — the runtime example now stands on its own.

## Test plan

- [x] Sidebar shows a single Integrations group with Make and Zapier alphabetized
- [x] /setup/spam-protection renders intro, list, image, conditions, then the comparison table, then Botpoison
- [x] /setup/file-uploads renders Uploadcare walkthrough first, Alternatives last
- [x] /customization/custom-routing renders intro + single runtime code block, no Hugo/Jekyll subsections