### PR TITLE
Document the native Notion integration

### DIFF
--- a/docs/integration/notion.md
+++ b/docs/integration/notion.md
@@ -18,6 +18,8 @@ Notion is available on all paid workspaces.
 
 You do not pick an existing database: Formspark always creates a new one, as a child of whichever page you shared.
 
+Notion's consent screen lets you share more than one page. If you do, Formspark uses the one you edited most recently as the parent, so share only the page you want the database to live in.
+
 ## What gets sent
 
 Each submission becomes a new entry in the database, with one property per field name your form submits.
@@ -27,6 +29,12 @@ Each submission becomes a new entry in the database, with one property per field
 ::: warning
 Sharing a page happens on Notion's own consent screen, not in a Formspark setting: Formspark cannot create a database anywhere you have not explicitly shared with it. If you get through the consent screen without selecting a page, the connection fails. Reconnect from your form's settings and make sure you select a page to share before confirming.
 :::
+
+## If a submission does not arrive
+
+Submissions are never lost when Notion is unreachable. Formspark keeps the submission and retries it in the background, oldest first, so a temporary Notion outage catches up on its own once it clears.
+
+If the retries keep failing, or if the Notion workspace has revoked access, the `Notion` card shows a sync error and stops trying. Use `Retry sync` on the card once the cause is fixed, or reconnect if access was revoked.
 
 ## Disconnecting
 

--- a/docs/integration/notion.md
+++ b/docs/integration/notion.md
@@ -11,8 +11,8 @@ Notion is available on all paid workspaces.
 
 ## Connecting
 
-1. Open your form's settings and find the `Notion` card under `Integrations`.
-2. Click `Connect Notion` and sign in to the Notion workspace you want to use.
+1. Open your form's settings and find the `Notion` row under `Integrations`.
+2. Click `Connect`, then `Connect Notion`, and sign in to the Notion workspace you want to use.
 3. On Notion's own consent screen, select the page you want to share with Formspark, then confirm access.
 4. Formspark creates a new database as a child of the page you shared and starts sending submissions to it.
 
@@ -22,7 +22,11 @@ Notion's consent screen lets you share more than one page. If you do, Formspark 
 
 ## What gets sent
 
-Each submission becomes a new entry in the database, with one property per field name your form submits.
+Each submission becomes a new entry in the database, with one property per field name your form submits. A field your form has not sent before is added to the database the first time it appears, so the database keeps up as a form changes.
+
+Alongside your own fields, every database carries two properties Formspark fills in: `Submission`, the entry's title, and `Submitted at`, the submission time as a date you can sort and filter on.
+
+Values are stored as text, so a Notion property never tries to interpret a submitted value. Very long values are truncated.
 
 ## If no page is shared
 
@@ -34,10 +38,10 @@ Sharing a page happens on Notion's own consent screen, not in a Formspark settin
 
 Submissions are never lost when Notion is unreachable. Formspark keeps the submission and retries it in the background, oldest first, so a temporary Notion outage catches up on its own once it clears.
 
-If the retries keep failing, or if the Notion workspace has revoked access, the `Notion` card shows a sync error and stops trying. Use `Retry sync` on the card once the cause is fixed, or reconnect if access was revoked.
+If the retries keep failing, or if the Notion workspace has revoked access, the `Notion` row shows a sync error and stops trying. Open the row with `Configure` and use `Retry sync` once the cause is fixed, or reconnect if access was revoked.
 
 ## Disconnecting
 
-Click `Disconnect Notion` in the same card to stop sending submissions. Disconnecting does not delete the database or the page it lives in, they stay in your Notion workspace with whatever entries were already added; Formspark simply stops writing to it.
+Open the `Notion` row with `Configure` and click `Disconnect Notion` to stop sending submissions. Disconnecting does not delete the database or the page it lives in, they stay in your Notion workspace with whatever entries were already added; Formspark simply stops writing to it.
 
 To send submissions to a different page, disconnect and connect again, and share a different page this time.

--- a/docs/integration/notion.md
+++ b/docs/integration/notion.md
@@ -5,22 +5,31 @@ lang: en-US
 
 # Notion
 
-Formspark does not connect to Notion directly. The recommended path is to use Zapier or Make as a bridge.
+Formspark can send every submission from your form straight into a Notion database, created automatically inside a page you share during setup.
 
-## Via Zapier
+Notion is available on all paid workspaces.
 
-1. Set up the Formspark [Zapier integration](/integration/zapier).
-2. In your Zap, select `New Submission` as the trigger.
-3. Add `Notion` as the action and choose `Create Database Item`.
-4. Map your form fields to the matching Notion database properties.
+## Connecting
 
-## Via Make
+1. Open your form's settings and find the `Notion` card under `Integrations`.
+2. Click `Connect Notion` and sign in to the Notion workspace you want to use.
+3. On Notion's own consent screen, select the page you want to share with Formspark, then confirm access.
+4. Formspark creates a new database as a child of the page you shared and starts sending submissions to it.
 
-1. Set up the Formspark [Make integration](/integration/make).
-2. In your scenario, select `Formspark` → `New Submission` as the trigger.
-3. Add a `Notion` → `Create a Database Item` module.
-4. Map your form fields to the matching Notion database properties.
+You do not pick an existing database: Formspark always creates a new one, as a child of whichever page you shared.
 
-## A note on direct webhooks
+## What gets sent
 
-It is possible to point your form's `Webhook URL` directly at Notion's API, but Notion enforces a 3-requests-per-second rate limit and returns submission errors that need to be retried. Zapier and Make handle this for you, so we recommend going through one of them unless you are comfortable building your own retry layer.
+Each submission becomes a new entry in the database, with one property per field name your form submits.
+
+## If no page is shared
+
+::: warning
+Sharing a page happens on Notion's own consent screen, not in a Formspark setting: Formspark cannot create a database anywhere you have not explicitly shared with it. If you get through the consent screen without selecting a page, the connection fails. Reconnect from your form's settings and make sure you select a page to share before confirming.
+:::
+
+## Disconnecting
+
+Click `Disconnect Notion` in the same card to stop sending submissions. Disconnecting does not delete the database or the page it lives in, they stay in your Notion workspace with whatever entries were already added; Formspark simply stops writing to it.
+
+To send submissions to a different page, disconnect and connect again, and share a different page this time.


### PR DESCRIPTION
## What
Split out of #168, Notion half only. Rewrites `docs/integration/notion.md` to describe the native per-form OAuth integration instead of the old Zapier/Make-bridge instructions.

## Do not merge yet
Notion integration is not live on `formspark/monorepo` yet (PR #95 there is still missing a test-suite run and has an unresolved page-picker gap). Merge only once it ships, otherwise the docs site describes a feature nobody can use.

## Verification
- `npm run build` (vitepress) completes cleanly, page renders.
- `npx prettier --check` passes.
- No screenshots yet — someone with dashboard access should add them in a follow-up once it's live.