### PR TITLE
Take the nanoid and postcss advisories out of the shipped tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -2191,9 +2191,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2210,7 +2210,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Found while checking this repository over before letting an agent near it.
`osv-scanner` reported eight advisories against `package-lock.json`. Four of
them are in the tree that ships, and this closes those four.

## What moved

Both packages are transitive and both move by a patch, so the range in
`package.json` does not change. Only the lock file does.

| Package | From | To | Clears |
| --- | --- | --- | --- |
| nanoid | 3.3.12 | 3.3.18 | GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 |
| postcss | 8.5.14 | 8.5.26 | GHSA-fxqj-rqcc-2cmp, GHSA-r28c-9q8g-f849 |

## What stays, and why

The other four are `vite` and `esbuild`, and both are dev only. The built site
does not carry them, so the advisories reach a developer running the dev server
and not a visitor.

Fixing them needs vite 6. `vitepress` 1.6.4 asks for vite `^5.4.14`, and 1.6.4
is the newest release: no stable 2.x exists, and `2.0.0-alpha.19` asks for vite
`^8.2.0`. Putting a prerelease under the documentation site, four majors of vite
at once, buys less than it risks. This is worth revisiting when vitepress 2 is
released.

## Checked

- `npm run build` completes, 6.7s, pages and sitemap rendered
- `npm run dev` serves 200 on 5173
- `osv-scanner` reports four advisories rather than eight, and none in the
  shipped tree