### PR TITLE
Say how often Zapier checks for submissions, and what waiting means

### DIFF
--- a/docs/integration/zapier.md
+++ b/docs/integration/zapier.md
@@ -12,3 +12,23 @@ Connecting Formspark and Zapier takes only seconds.
 3. Paste your copied key when prompted.
 
 ![Formspark with Zapier](/formspark-zapier-example.png)
+
+## How often Zapier checks for submissions
+
+Zapier does not wait for Formspark to push a submission. It asks Formspark for new submissions on a schedule of its own, and how often it asks depends on your Zapier plan.
+
+On [upgraded workspaces](/troubleshooting/limits-and-plans), Formspark answers every one of those checks, so submissions reach your Zap as quickly as Zapier asks for them.
+
+On free workspaces, Formspark answers at most one check every 15 minutes. Checks that arrive sooner are told to try again shortly, and Zapier reschedules them on its own. A submission can therefore take up to 15 minutes to reach your Zap.
+
+## Waiting runs in Zap history
+
+When Formspark asks Zapier to try again, the run appears in [Zap history](https://help.zapier.com/hc/en-us/articles/20505304170637-Review-Zap-run-statuses) as waiting or scheduled rather than as an error. Nothing has gone wrong and there is nothing to fix: Zapier picks the run back up once the wait is over.
+
+::: tip
+No submission is lost while a check is waiting. Submissions that arrive during the wait are still there for the next check, so the only difference on a free workspace is how soon your Zap sees them, never whether it sees them.
+:::
+
+## If your key stops working
+
+Regenerating a form's `Zapier key` takes effect immediately, and the old key stops being accepted. If your Zap starts failing to connect after you regenerate, paste the new key into the Formspark connection in Zapier.

--- a/docs/troubleshooting/limits-and-plans.md
+++ b/docs/troubleshooting/limits-and-plans.md
@@ -40,3 +40,7 @@ Upgrades, bundles, and deals apply to a single workspace. Additional user-create
 ## Team members
 
 Free workspaces include 5 team members. Upgraded workspaces have no practical member limit. Members who joined before a limit applied always keep their access; limits only affect new invitations. See [inviting team members](/dashboard/inviting-team-members).
+
+## How quickly Zapier sees a submission
+
+Zapier checks Formspark for new submissions on a schedule of its own. Upgraded workspaces are answered every time, so a submission reaches your Zap as quickly as Zapier asks for it. Free workspaces are answered at most once every 15 minutes, so a submission can take that long to arrive. No submission is lost either way. See [Zapier](/integration/zapier#how-often-zapier-checks-for-submissions).


### PR DESCRIPTION
Documents the free-plan Zapier poll throttle introduced in formspark/monorepo#164.

> [!IMPORTANT]
> **Merge after formspark/monorepo#164 ships.** This describes behaviour that does not exist in production yet.

## What it adds

**`integration/zapier.md`** gains three sections:

- **How often Zapier checks for submissions.** Zapier polls rather than receiving a push. Upgraded workspaces are answered every time; free workspaces at most once every 15 minutes, so a submission can take that long to arrive.
- **Waiting runs in Zap history.** The part most worth stating plainly: a waiting or scheduled run is not a failure. Someone who has not been told otherwise will read it as one and open a ticket.
- **If your key stops working.** Regenerating a key takes effect immediately, which is the other reason a working Zap suddenly stops connecting.

**`troubleshooting/limits-and-plans.md`** gains a matching section so the plan comparison stays the canonical list, linking through to the Zapier page.

## Notes

- No submission is lost while a check is waiting, and both pages say so explicitly. That is the question a customer will actually have.
- The existing "Webhooks, Slack and Zapier | Included | Included" table row is left alone. Zapier is still included on both plans; only the cadence differs, which the new section covers.
- `npm run build` passes and the cross-page anchor resolves in the generated HTML.