### PR TITLE
Bump @sentry/vue from 10.0.0 to 10.70.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sentry/vue": "^10.0.0"
+        "@sentry/vue": "^10.70.0"
       },
       "devDependencies": {
         "husky": "^9.0.0",
@@ -1151,96 +1151,111 @@
         "win32"
       ]
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.52.0.tgz",
-      "integrity": "sha512-x/yEPZdpH6NGQeoeQnV9tj8reAH8twNttiltGZl2o8Rk7sQeUfe7E8yuYP2XbJ2RqyZK5qRS3COrNyMPzf6KFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.52.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.52.0.tgz",
-      "integrity": "sha512-5kAn1W8ZvCuHtEHXpq6iRkUMdNCilwww+YxaN2yofVrCivAbB3Ha5JJUMqmWOPW0pC27zGYmoJMIDvG+PczUxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.52.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.52.0.tgz",
-      "integrity": "sha512-diywyuc/H7VTUR+W5ryVmLF+0X4UP1OskMqb6V8RSAvJHcj2JmIm7uP+Fc6ACTno+b6AUShwT/L4xVXzO6X9Cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.52.0",
-        "@sentry/core": "10.52.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.52.0.tgz",
-      "integrity": "sha512-BI5ie4dxPuUJ344CXVSnAxY1xZCbghglPSCIlTOYODpR9so9yo5IZh+Mwspt0oWsUMaxWJiQSNYlbPWi7WDavg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.52.0",
-        "@sentry/core": "10.52.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/browser": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.52.0.tgz",
-      "integrity": "sha512-ijL9jN86oXwXQWbwhPlEb70ODJSEmjxQEQdnZkC4gDWbjswcwvRsVJPYk+1xl2ir2iZixRIHipVxDcLwian35g==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
+      "integrity": "sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.52.0",
-        "@sentry-internal/feedback": "10.52.0",
-        "@sentry-internal/replay": "10.52.0",
-        "@sentry-internal/replay-canvas": "10.52.0",
-        "@sentry/core": "10.52.0"
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/feedback": "10.70.0",
+        "@sentry/replay": "10.70.0",
+        "@sentry/replay-canvas": "10.70.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.70.0.tgz",
+      "integrity": "sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.52.0.tgz",
-      "integrity": "sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
       "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.70.0.tgz",
+      "integrity": "sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.70.0.tgz",
+      "integrity": "sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.70.0.tgz",
+      "integrity": "sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0",
+        "@sentry/replay": "10.70.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "10.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.52.0.tgz",
-      "integrity": "sha512-6MHYKXGQz39yFJ27HzNYGWJtmwDhEwp7EvCm6cJPBlXQNbYOoNTDrzq4TuI0cLJzyAW7mIQ+k4n4iMpa6EbfaA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.70.0.tgz",
+      "integrity": "sha512-oopTjKv8/WvxBeRDmgh3xJtEAbP/K0qmtAkOkj9jDYAYN5mgBm33sv7cYHXdrAR4o6tE1VFVu2hWqge64dGbHw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.52.0",
-        "@sentry/core": "10.52.0"
+        "@sentry/browser": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@tanstack/vue-router": "^1.64.0",
-        "pinia": "2.x || 3.x",
+        "pinia": "2.x || 3.x || 4.x",
         "vue": "2.x || 3.x"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@sentry/vue": "^10.0.0"
+    "@sentry/vue": "^10.70.0"
   },
   "devDependencies": {
     "husky": "^9.0.0",


### PR DESCRIPTION
`@sentry/vue` `^10.0.0` → `^10.70.0` (dependencies).

This updates what `package.json` declares. The range may already have
permitted the newer version, in which case only the declaration was stale.

Lockfile resolved by `npm`, with no install and no lifecycle scripts.

Produced by a script, not a model — a lockfile is not something to write by hand.

<details><summary>Release notes</summary>

### 10.70.0

- feat(v10/core): Support stable MCP SDK v2 ([#22986](https://github.com/getsentry/sentry-javascript/pull/22986))
- feat(v10/deps): Bump `@sentry/node-cpu-profiler` to 2.4.3 ([#22992](https://github.com/getsentry/sentry-javascript/pull/22992))
- feat(v10/solid,solidstart): Support `@solidjs/router` v1 ([#23163](https://github.com/getsentry/sentry-javascript/pull/23163))
- fix(v10/cloudflare): Fork the isolation scope for Durable Object methods ([#23189](https://github.com/getsentry/sentry-javascript/pull/23189))
- fix(v10/cloudflare): Get original waituntil in workflows ([#23192](https://github.com/getsentry/sentry-javascript/pull/23192))
- fix(v10/cloudflare): Instrument DO RPC methods on the prototype, not a Proxy ([#23190](https://github.com/getsentry/sentry-javascript/pull/23190))
- fix(v10/cloudflare): Set agent conversation id on the `onRequest` path ([#22985](https://github.com/getsentry/sentry-javascript/pull/22985))
- fix(v10/cloudflare): Set conversation id independent of session name ([#23193](https://github.com/getsentry/sentry-javascript/pull/23193))
- fix(v10/cloudflare): Try/catch on non-configurable prototypes ([#23191](https://github.com/getsentry/sentry-javascript

…truncated; see the release link above.

### 10.69.0

### Important Changes

- **feat(v10/cloudflare): Add `instrumentAgentWithSentry` for Cloudflare Agents ([#22786](https://github.com/getsentry/sentry-javascript/pull/22786))**

The Cloudflare SDK adds a new `instrumentAgentWithSentry` API for [Cloudflare Agents](https://agents.cloudflare.com/). It works like `instrumentDurableObjectWithSentry` for `Agent` classes from the `agents` SDK and additionally creates spans for `@callable` RPC methods and automatically sets the `conversationId` based on the agent's name. When building with the Sentry Vite plugin, Agents are instrumented automatically ([#22788](https://github.com/getsentry/sentry-javascript/pull/22788)).

### Other Changes

- feat(v10/cloudflare): Add Spotlight integration for local dev event forwarding ([#22796](https://github.com/getsentry/sentry-javascript/pull/22796))
- feat(v10/cloudflare): Add wranglerConfigPath to Vite options ([#22803](https://github.com/getsentry/sentry-javascript/pull/22803))
- feat(v10/cloudflare): Filter framework-internal Durable Object storage spans ([#22770](https://github.com/getsentry/sentry-javascript/pull/22770))
- feat(v10/cloudflare): Instrument Agents automatically ([#22788](https://gith

…truncated; see the release link above.

### 10.68.0

- feat(cloudflare): Add @sentry/cloudflare/vite orchestrion plugin ([#21967](https://github.com/getsentry/sentry-javascript/pull/21967))
- feat(nestjs): Support WebSocket errors in SentryGlobalFilter ([#22224](https://github.com/getsentry/sentry-javascript/pull/22224))
- feat(node,server-utils): Set `cache.key` on dataloader spans and capture redis delete operations as `cache.remove` ([#22389](https://github.com/getsentry/sentry-javascript/pull/22389))
- feat(server-utils): Allow integrations to be part of marker ([#22094](https://github.com/getsentry/sentry-javascript/pull/22094))
- feat(server-utils): Migrate `FirebaseInstrumentation` to orchestrion ([#22141](https://github.com/getsentry/sentry-javascript/pull/22141))
- feat(server-utils): Warn when bundler config has instrumented module in external ([#22379](https://github.com/getsentry/sentry-javascript/pull/22379))
- feat(v10): Add `http.route` attribute to `http.server` spans with parameterized routes ([#22564](https://github.com/getsentry/sentry-javascript/pull/22564))
- feat(v10): Add `url.full` and `url.path` to `http.server` spans ([#22533](https://github.com/getsentry/sentry-javascript/pull/22533))
- feat(v10/cloudflare)

…truncated; see the release link above.

### 10.67.0

### Important Changes

- **feat(sveltekit): Add support for SvelteKit 3 ([#22264](https://github.com/getsentry/sentry-javascript/pull/22264))**

  The SvelteKit SDK now supports the pre-release of SvelteKit 3, including client-side pageload and navigation tracing and server-side native tracing, alongside continued SvelteKit 2 support. No Sentry-specific setup changes are required. The SDK detects your SvelteKit version and picks the right implementation automatically.

### Other Changes

- feat(aws-serverless): Use orchestrion aws-sdk integration under diagnostics-channel opt-in ([#22143](https://github.com/getsentry/sentry-javascript/pull/22143))
- feat(cloudflare): Auto-instrument Workers AI binding via env instrumentation ([#22126](https://github.com/getsentry/sentry-javascript/pull/22126))
- feat(cloudflare): Instrument Cloudflare rate limiter bindings ([#22035](https://github.com/getsentry/sentry-javascript/pull/22035))
- feat(core): Instrument workers-ai-provider ([#22119](https://github.com/getsentry/sentry-javascript/pull/22119))
- feat(core): Rename `queryParams` to `urlQueryParams` ([#22217](https://github.com/getsentry/sentry-javascript/pull/22217))
- feat(mongodb): impl

…truncated; see the release link above.

### 10.66.0

- chore(node-core): Deprecate `@sentry/node-core` package ([#22285](https://github.com/getsentry/sentry-javascript/pull/22285))
- chore(tanstackstart): Deprecate `@sentry/tanstackstart` package ([#22284](https://github.com/getsentry/sentry-javascript/pull/22284))
- deps(server-utils): bump @apm-js-collab/code-transformer and tracing-hooks ([#22172](https://github.com/getsentry/sentry-javascript/pull/22172))
- feat(bun): Add `initWithoutDefaultIntegrations` and `getDefaultIntegrationsWithoutPerformance` ([#22036](https://github.com/getsentry/sentry-javascript/pull/22036))
- feat(bundlers): Add orchestrion bundler plugins ([#22124](https://github.com/getsentry/sentry-javascript/pull/22124))
- feat(cloudflare): Support Cloudflare types v5 & newer wrangler versions ([#22180](https://github.com/getsentry/sentry-javascript/pull/22180))
- feat(core): Add and use `dataCollection.databaseQueryData` (for e.g. Supabase filter values and mutation bodies) ([#22219](https://github.com/getsentry/sentry-javascript/pull/22219))
- feat(core): Add and use `dataCollection.graphQL` ([#22221](https://github.com/getsentry/sentry-javascript/pull/22221))
- feat(core): Add stringify helper and make AI-traci

…truncated; see the release link above.

### 10.65.0

- feat(angular): Set `url` attributes on pageload and navigation spans ([#21985](https://github.com/getsentry/sentry-javascript/pull/21985))
- feat(astro): Set `url.template` on pageload spans ([#22011](https://github.com/getsentry/sentry-javascript/pull/22011))
- feat(aws-serverless): Replace OTel Lambda instrumentation with handler redirection ([#22079](https://github.com/getsentry/sentry-javascript/pull/22079))
- feat(browser): Set `url.path` and `url.full` on pageload and navigation spans ([#21952](https://github.com/getsentry/sentry-javascript/pull/21952))
- feat(bun): warn when externalizing instrumented deps ([#21999](https://github.com/getsentry/sentry-javascript/pull/21999))
- feat(core): Require `attributes` on `SerializedStreamedSpan` ([#22052](https://github.com/getsentry/sentry-javascript/pull/22052))
- feat(ember): Set `url.template`, `url.path` and `url.full` on router spans ([#22095](https://github.com/getsentry/sentry-javascript/pull/22095))
- feat(mysql2): Instrument mysql2 >= 3.20.0 via native tracing channels ([#21824](https://github.com/getsentry/sentry-javascript/pull/21824))
- feat(nextjs): Set `url` attributes on pageload and navigation spans ([#22006](https

…truncated; see the release link above.

### 10.64.0

### Important Changes

- **feat(cloudflare): Add `nodejs_compat` entrypoint ([#21881](https://github.com/getsentry/sentry-javascript/pull/21881))**

  The Cloudflare SDK now ships a dedicated `@sentry/cloudflare/nodejs_compat` entrypoint for Workers running with the `nodejs_compat` flag. This entrypoint unlocks Node SDK features on Cloudflare, including the `prismaIntegration` ([#21882](https://github.com/getsentry/sentry-javascript/pull/21882)) and AI v7 support for the `vercelAiIntegration` ([#21917](https://github.com/getsentry/sentry-javascript/pull/21917)).

  This entrypoint is a drop-in replacement, so you can switch your imports from `@sentry/cloudflare` directly to `@sentry/cloudflare/nodejs_compat`. To use it, your Worker must set the `nodejs_compat` compatibility flag in `wrangler.toml`/`wrangler.jsonc`. This will become the default entrypoint in v11.

- **feat: Use Sentry's minimal OpenTelemetry tracer provider by default ([#21666](https://github.com/getsentry/sentry-javascript/pull/21666), [#21680](https://github.com/getsentry/sentry-javascript/pull/21680), [#21842](https://github.com/getsentry/sentry-javascript/pull/21842))**

  The Node SDK now registers Sentry's own

…truncated; see the release link above.

### 10.63.0

- feat(browser): Add `url.full` attribute to resource spans ([#21846](https://github.com/getsentry/sentry-javascript/pull/21846))
- feat(core): Add `extendIntegration` method ([#21759](https://github.com/getsentry/sentry-javascript/pull/21759))
- feat(core): Add `isTracingSuppressed` to the async context strategy ([#21785](https://github.com/getsentry/sentry-javascript/pull/21785))
- feat(core): Pass normalizedRequest to the sampling context for root spans ([#21833](https://github.com/getsentry/sentry-javascript/pull/21833))
- feat(node): Add lru-memoizer diagnostics-channel integration to experimentalUseDiagnosticsChannelInjection ([#21786](https://github.com/getsentry/sentry-javascript/pull/21786))
- feat(node): Expose channel-based, streamlined `fastifyIntegration` ([#21706](https://github.com/getsentry/sentry-javascript/pull/21706))
- fix(browser): Defer sending session envelope until browser is idle ([#21844](https://github.com/getsentry/sentry-javascript/pull/21844))
- fix(core): Improve waiting for tracing channel bindings ([#21815](https://github.com/getsentry/sentry-javascript/pull/21815))
- fix(core): Serialize streamed span status message to `sentry.status.message` attri

…truncated; see the release link above.

_71 earlier release(s) in this range are not shown._

Releases: https://github.com/getsentry/sentry-javascript/releases

</details>

---
Proposed by the `dependency-freshness` agent and approved in Cadre.