### PR TITLE
Say that the Webflow blocks are alternatives, and stop quoting Uploadcare's free tier

### DIFF
--- a/docs/examples/webflow.md
+++ b/docs/examples/webflow.md
@@ -7,9 +7,18 @@ lang: en-US
 
 1. Copy your form's action URL.
 2. Paste the action URL into Webflow's `action` field in the form element’s settings in the Designer.
-3. Copy-paste the code below into `Project Settings > Custom Code > Footer Code`.
+3. Copy-paste one of the code blocks below into `Project Settings > Custom Code > Footer Code`.
 
 ![Webflow action](/webflow-action.jpeg)
+
+::: warning
+Each code block on this page is complete on its own, and they are alternatives rather than
+additions. Use exactly one.
+
+Every block binds its own submit handler to the same form, so pasting two of them submits the form
+twice. The copy without spam protection sends no challenge token, Formspark rejects it, and Webflow
+paints the error state over a submission that actually succeeded.
+:::
 
 ```html
 <!-- Project Settings > Custom Code > Footer Code -->
@@ -47,6 +56,9 @@ lang: en-US
 
 ## Redirect after submission
 
+Replaces the first code block on this page: it redirects instead of showing Webflow's success and
+error states.
+
 ```html
 <!-- Project Settings > Custom Code > Footer Code -->
 
@@ -79,6 +91,9 @@ lang: en-US
 ```
 
 ## Botpoison spam protection
+
+Replaces the first code block on this page. Use this one on its own when the form has Botpoison
+enabled.
 
 ```html
 <!-- Project Settings > Custom Code > Footer Code -->
@@ -128,6 +143,9 @@ lang: en-US
 ```
 
 ## Turnstile spam protection
+
+Replaces the first code block on this page. Use this one on its own when the form has Turnstile
+enabled.
 
 1. First, add a Turnstile widget element to your form:
 

--- a/docs/setup/file-uploads.md
+++ b/docs/setup/file-uploads.md
@@ -9,15 +9,19 @@ lang: en-US
 Formspark stores a link to your uploaded file, not the file itself. You upload the file to a third-party storage provider and Formspark records the resulting URL with the submission.
 :::
 
-The example below uses Uploadcare. Any provider that returns a public URL after upload will work the same way.
+The examples below use Uploadcare and Cloudinary. Any provider that returns a public URL after upload will work the same way.
 
 ## Uploadcare
 
-Create a free Uploadcare account at [https://uploadcare.com/](https://uploadcare.com/). Their free tier gives you 3000
-uploads per month.
+Create an Uploadcare account at [https://uploadcare.com/](https://uploadcare.com/).
 
-Want to upload non-image files? You can add a payment method to your Uploadcare account without having to leave their
-free plan.
+::: warning
+Uploadcare's free plan is metered in operations, not uploads, and an operation covers uploading,
+image transformations, video processing and document conversion alike. The allowance is small enough
+that a busy form will pass it, and the cheapest paid plan is a significant step up. Check
+[their pricing](https://uploadcare.com/pricing/) against your expected volume before you commit, and
+see [Cloudinary](#cloudinary) below for another option.
+:::
 
 ### Steps
 
@@ -95,9 +99,67 @@ Final code:
 </html>
 ```
 
+## Cloudinary
+
+[Cloudinary](https://cloudinary.com/) offers an upload widget that works the same way: the visitor
+uploads, and you put the resulting URL into a hidden field that Formspark records.
+
+### Steps
+
+Create an [unsigned upload preset](https://cloudinary.com/documentation/upload_presets) in your
+Cloudinary console. Unsigned is what lets the browser upload without a server-side signature, so the
+preset should restrict what it accepts.
+
+Add the widget script to the `head` of your HTML file.
+
+```html
+<script
+  src="https://upload-widget.cloudinary.com/latest/global/all.js"
+  type="text/javascript"
+></script>
+```
+
+Add a hidden input to hold the URL, and a button that opens the widget.
+
+```html
+<!-- Photo -->
+<input type="hidden" id="photo" name="photo" />
+<button type="button" id="upload-widget">Upload a photo</button>
+```
+
+Wire the widget up so a successful upload writes its URL into that input.
+
+```html
+<script type="text/javascript">
+  var widget = cloudinary.createUploadWidget(
+    {
+      cloudName: "your-cloud-name",
+      uploadPreset: "your-unsigned-upload-preset",
+    },
+    function (error, result) {
+      if (!error && result && result.event === "success") {
+        document.getElementById("photo").value = result.info.secure_url;
+      }
+    },
+  );
+
+  document
+    .getElementById("upload-widget")
+    .addEventListener("click", function () {
+      widget.open();
+    });
+</script>
+```
+
+The submitted `photo` field now carries the uploaded file's URL.
+
+::: tip
+Give the button `type="button"`. A button inside a form defaults to `type="submit"`, so without it
+opening the widget submits the form instead.
+:::
+
 ## Alternatives
 
-- [Cloudinary](https://cloudinary.com/): image and video focused, generous free tier.
 - [Filestack](https://www.filestack.com/): drop-in widget similar to Uploadcare.
 - [Bunny Storage](https://bunny.net/storage/): cheap edge storage with a simple HTTP API.
 - [Amazon S3 pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html): generate an upload URL from your own backend, then submit the resulting file URL to Formspark.


### PR DESCRIPTION
## Webflow

Every code block on the Webflow page is complete on its own, but the page read as a base snippet followed by add-ons, so a reader naturally pastes the base one and then the spam-protection one.

Two blocks bind two jQuery submit handlers to the same form, so one visitor submit sends two POSTs. The copy without spam protection carries no challenge token, gets refused, and its error callback paints `.w-form-fail`; the other clears its challenge and lands a 200 about two seconds later. The customer sees a submission that arrived and an error message next to it.

This surfaced as a support ticket. In the logs the signature is a matched pair per submit, one 403 in ~40ms and one 200 in ~2s, and the rejected twin carries the same fields as the accepted one with no `_botpoison`. It has been happening all along; answering a refused submission with 4xx rather than 200 is what turned a silent duplicate into a visible error.

Each variant now says which block it replaces, and a warning up top says to use exactly one.

## File uploads

Uploadcare's free tier is no longer 3000 uploads a month. It is metered in operations, which cover transformations, video processing and document conversion as well as uploads, and the cheapest paid plan is a large step up. Reported by a customer who found the numbers no longer matched.

Dropped the specific figures and the claim that a payment method can be added without leaving the free plan, which could not be verified, in favour of a pointer to their pricing. Added a Cloudinary walkthrough as a second worked example, which is what the same customer asked for, using an unsigned upload preset and the upload widget writing `secure_url` into a hidden field.