### PR TITLE
Let the per-variant lines carry the Webflow warning on their own

### DIFF
--- a/docs/examples/webflow.md
+++ b/docs/examples/webflow.md
@@ -11,15 +11,6 @@ lang: en-US
 
 ![Webflow action](/webflow-action.jpeg)
 
-::: warning
-Each code block on this page is complete on its own, and they are alternatives rather than
-additions. Use exactly one.
-
-Every block binds its own submit handler to the same form, so pasting two of them submits the form
-twice. The copy without spam protection sends no challenge token, Formspark rejects it, and Webflow
-paints the error state over a submission that actually succeeded.
-:::
-
 ```html
 <!-- Project Settings > Custom Code > Footer Code -->
 


### PR DESCRIPTION
Follow-up to #182.

Each variant already says it replaces the first code block, which is the part a reader acts on. The banner above them restated it at length for a mistake one customer has made, so it goes and the per-variant lines stay.